### PR TITLE
パンくずリストをマイページでの実装

### DIFF
--- a/app/views/oshi_profiles/edit.html.erb
+++ b/app/views/oshi_profiles/edit.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :edit_oshi_profile, @oshi_profile %>
 <div class="container mx-auto flex px-5 py-24 items-center justify-center flex-col">
   <div class="bg-white shadow-md p-6 rounded-lg max-w-5xl w-full lg:w-2/3">
     <h1 class="text-4xl font-bold mb-6 text-center">推しプロフィール編集</h1>
@@ -56,7 +57,7 @@
       </div>
     <% end %>
     <div class='text-center mb-6'>
-      <%= button_to 'プロフィールを削除', oshi_profile_path, method: :delete, class: 'text-white bg-red-500 border-0 py-2 px-6 focus:outline-none hover:bg-red-600 rounded text-lg' %>
+      <%= button_to 'プロフィールを削除', oshi_profile_path, method: :delete, data: { turbo_confirm: "削除しますか?" }, class: 'text-white bg-red-500 border-0 py-2 px-6 focus:outline-none hover:bg-red-600 rounded text-lg' %>
     </div>
     <div class='text-center'>
       <%= link_to "マイページに戻る", mypage_path, class: 'text-gray-700 decoration-2 underline-offset-4 transition-colors hover:underline' %>

--- a/app/views/oshi_profiles/new.html.erb
+++ b/app/views/oshi_profiles/new.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :new_oshi_profile %>
 <div class="container mx-auto flex px-5 py-24 items-center justify-center flex-col">
   <div class="bg-white shadow-md p-6 rounded-lg max-w-5xl w-full lg:w-2/3">
     <h1 class="text-4xl font-bold mb-6 text-center">推しプロフィール設定</h1>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :mypage %>
 <div class="container mx-auto flex px-5 py-12 items-center justify-center flex-col mt-16">
   <div class="bg-white shadow-md p-6 rounded-lg max-w-5xl w-full lg:w-2/3">
       <div class="flex justify-between items-center mb-6 border-b border-black pb-2">

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,6 +2,21 @@ crumb :root do
   link "Home", root_path
 end
 
+crumb :mypage do
+  link "マイページ", mypage_path
+  parent :root
+end
+
+crumb :new_oshi_profile do
+  link "推しプロフィール設定", new_oshi_profile_path
+  parent :mypage
+end
+
+crumb :edit_oshi_profile do |oshi_profile|
+  link "推しプロフィール編集", edit_oshi_profile_path(oshi_profile)
+  parent :mypage
+end
+
 crumb :tasks do
   link "タスク一覧", tasks_path
   parent :root


### PR DESCRIPTION
- パンくずリストをマイページで実装
- 推しプロフィール削除時に確認するダイアログの実装