### PR TITLE
トップページ、ヘッダー、フッターのレスポンシブデザインの実装

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <script defer src="https://unpkg.com/alpinejs@3.3.4/dist/cdn.min.js"></script>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
     <%= display_meta_tags(default_meta_tags) %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -6,22 +6,8 @@
           <%= image_tag 'OshiTask_logo2.png', class: 'h-16 w-auto' %>
         <% end %>
       </div>
-      <div class="flex items-center">
-        <div class="block lg:hidden">
-          <button class="text-gray-500 hover:text-gray-700 focus:outline-none focus:text-gray-700" @click="isOpen = !isOpen">
-            <svg class="h-6 w-6 fill-current" viewBox="0 0 24 24">
-              <path v-if="!isOpen" d="M4 6h16M4 12h16M4 18h16"></path>
-              <path v-if="isOpen" d="M6 18L18 6M6 6l12 12"></path>
-            </svg>
-          </button>
-        </div>
-        <div :class="{'block': isOpen, 'hidden': !isOpen}" class="w-full lg:flex lg:items-center lg:w-auto">
-          <ul class="flex flex-col lg:flex-row lg:space-x-4">
-            <li class="relative group">
-              <%= link_to 'ログイン', login_path, class: 'block lg:inline-block px-3 py-2 text-gray-700 hover:text-gray-900' %>
-            </li>
-          </ul>
-        </div>
+      <div>
+        <%= link_to 'ログイン', login_path, class: 'block lg:inline-block px-3 py-2 text-gray-700 hover:text-gray-900' %>
       </div>
     </div>
   </nav>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,10 +1,10 @@
 <footer class="bg-gray-800 text-white p-4">
   <div class="container mx-auto text-center">
-    <p>&copy; 2024 てりやきはるまき. All rights reserved.</p>
-    <ul class="flex justify-center space-x-4 mt-2">
+    <ul class="flex flex-col md:flex-row justify-center md:space-x-4 mt-2 space-y-2 md:space-y-0">
       <li><%= link_to '利用規約', terms_path, class: 'hover:underline' %></li>
       <li><%= link_to 'プライバシーポリシー', privacy_path, class: 'hover:underline' %></li>
       <li><%= link_to 'お問い合わせ', contact_path, class: 'hover:underline' %></li>
     </ul>
+    <p class="mt-4">&copy; 2024 てりやきはるまき. All rights reserved.</p>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header>
+<header x-data="{ isOpen: false }" class="relative">
   <nav class="bg-white shadow-md w-full">
     <div class="flex justify-between items-center px-6 py-3">
       <div class="flex items-center">
@@ -6,29 +6,26 @@
           <%= image_tag 'OshiTask_logo2.png', class: 'h-16 w-auto' %>
         <% end %>
       </div>
-      <div class="flex items-center">
-        <div class="block lg:hidden">
-          <button class="text-gray-500 hover:text-gray-700 focus:outline-none focus:text-gray-700" @click="isOpen = !isOpen">
-            <svg class="h-6 w-6 fill-current" viewBox="0 0 24 24">
-              <path v-if="!isOpen" d="M4 6h16M4 12h16M4 18h16"></path>
-              <path v-if="isOpen" d="M6 18L18 6M6 6l12 12"></path>
-            </svg>
-          </button>
-        </div>
-        <div :class="{'block': isOpen, 'hidden': !isOpen}" class="w-full lg:flex lg:items-center lg:w-auto">
-          <ul class="flex flex-col lg:flex-row lg:space-x-4">
-            <li class="relative group">
-              <%= link_to 'マイページ', mypage_path, class: 'block lg:inline-block px-3 py-2 text-gray-700 hover:text-gray-900' %>
-            </li>
-            <li class="relative group">
-              <%= link_to 'タスク一覧', tasks_path, class: 'block lg:inline-block px-3 py-2 text-gray-700 hover:text-gray-900' %>
-            </li>
-            <li class="relative group">
-              <%= link_to 'ログアウト', logout_path, class: 'block lg:inline-block px-3 py-2 text-gray-700 hover:text-gray-900', data: { turbo_method: :delete } %>
-            </li>
-          </ul>
-        </div>
+      <div class="block lg:hidden">
+        <button @click="isOpen = !isOpen" class="text-gray-500 hover:text-gray-700 focus:outline-none">
+          <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path x-show="!isOpen" d="M4 6h16M4 12h16M4 18h16" stroke-linecap="round" />
+            <path x-show="isOpen" d="M6 18L18 6M6 6l12 12" stroke-linecap="round" />
+          </svg>
+        </button>
+      </div>
+      <div class="hidden lg:flex lg:items-center lg:space-x-4">
+        <%= link_to 'マイページ', mypage_path, class: 'px-3 py-2 text-gray-700 hover:text-gray-900' %>
+        <%= link_to 'タスク一覧', tasks_path, class: 'px-3 py-2 text-gray-700 hover:text-gray-900' %>
+        <%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: 'px-3 py-2 text-gray-700 hover:text-gray-900' %>
       </div>
     </div>
   </nav>
+  <div x-show="isOpen" class="lg:hidden absolute top-full left-0 w-full bg-white shadow-md z-10">
+    <div class="flex flex-col items-center text-center px-6 py-4 space-y-2">
+      <%= link_to 'マイページ', mypage_path, class: 'text-gray-700 hover:text-gray-900' %>
+      <%= link_to 'タスク一覧', tasks_path, class: 'text-gray-700 hover:text-gray-900' %>
+      <%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: 'text-gray-700 hover:text-gray-900' %>
+    </div>
+  </div>
 </header>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,12 +1,17 @@
 <div class="container mx-auto flex px-5 py-24 items-center justify-center flex-col">
   <div class="bg-white shadow-md p-6 rounded-lg max-w-5xl w-full lg:w-2/3">
     <h1 class="text-4xl font-bold mb-6 text-center">推しTaskとは？</h1>
-    <div class="mb-6 px-4 flex justify-center">
-      <p class="text-gray-700 pl-4 text-xl">タスクを達成するたびに、推しから激励の言葉をもらえるタスク管理アプリです。</p>
+    <div class="mb-9 px-4 text-center">
+      <p class="text-xl text-gray-700 text-center leading-relaxed block sm:hidden">
+        タスクを達成するたびに、<br>
+        推しから褒めて貰える<br>
+        タスク管理サービスです。
+      </p>
+      <p class="text-xl text-gray-700 text-center leading-relaxed hidden sm:block">
+        タスクを達成するたびに、推しから褒めて貰えるタスク管理サービスです。
+      </p>
     </div>
-    <div class="px-4 flex justify-center">
-      <p class="text-gray-700 pl-4 text-xl">推しと一緒にタスクをこなしていきましょう！</p>
-    </div>
+    <h2 class="text-4xl font-bold text-center">利用方法</h2>
     <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
     <section class="text-gray-600 body-font" x-data="{ step: 1 }">
       <div class="container px-5 py-6 mx-auto flex flex-wrap flex-col">
@@ -41,37 +46,89 @@
           </a>
         </div>
         <div x-show="step === 1" class="text-center">
-          <h1 class="text-2xl font-medium text-gray-900 mb-6">STEP 1: ログイン</h1>
+          <h1 class="text-2xl font-medium text-gray-900 mb-6">
+            STEP 1 <br class="block sm:hidden">
+            ログイン
+          </h1>
           <img class="w-full sm:w-3/4 md:w-2/3 lg:w-1/2 xl:w-[95%] max-w-6xl block mx-auto mb-6 object-cover object-center rounded" 
           alt="step1" src="<%= asset_path('STEP1.png') %>">
-          <p class="text-base text-xl">
+          <p class="text-base text-xl block sm:hidden">
+            <%= link_to "こちら", login_path, class: "text-indigo-500 hover:underline" %>から<br>
+            会員登録を行いましょう
+          </p>
+          <p class="text-base text-xl block sm:hidden">
+            （googleによる<br>
+            登録も可能です）
+          </p>
+          <p class="text-base text-xl hidden sm:block">
             <%= link_to "こちら", login_path, class: "text-indigo-500 hover:underline" %>から会員登録を行いましょう
           </p>
-          <p class="text-base text-xl">（googleによる登録も可能です）</p>
+          <p class="text-base text-xl hidden sm:block">（googleによる登録も可能です）</p>
         </div>
         <div x-show="step === 2" class="text-center">
-          <h1 class="text-2xl font-medium text-gray-900 mb-6">STEP 2: 推しプロフィール登録</h1>
+          <h1 class="text-2xl font-medium text-gray-900 mb-6">
+            STEP 2 <br class="block sm:hidden">
+            推しプロフィール登録
+          </h1>
           <img class="w-full sm:w-3/4 md:w-2/3 lg:w-1/2 xl:w-[95%] max-w-6xl block mx-auto mb-6 object-cover object-center rounded" 
           alt="step2" src="<%= asset_path('STEP2.png') %>">
-          <p class="text-base text-xl">マイページから推しの情報を登録しましょう！</p>
-          <p class="text-base text-xl">画像、名前、性格、年齢、性別、一人称の登録ができます！</p>
-          <p class="text-base text-xl">（設定時にAIによるコメントが生成されるため、数分かかります）</p>
+          <p class="text-base text-xl block sm:hidden">
+            マイページから<br>
+            推しの情報を<br>
+            登録しましょう！
+          </p>
+          <p class="text-base text-xl block sm:hidden">
+            画像、名前、性格、<br>
+            年齢、性別、一人称の<br>
+            登録ができます！
+          </p>
+          <p class="text-base text-xl block sm:hidden">
+            （登録時にAIが<br>
+            コメントを生成するため、<br>
+            数分かかります）
+          </p>
+          <p class="text-base text-xl hidden sm:block">マイページから推しの情報を登録しましょう！</p>
+          <p class="text-base text-xl hidden sm:block">画像、名前、性格、年齢、性別、一人称の登録ができます！</p>
+          <p class="text-base text-xl hidden sm:block">（登録時にAIがコメントを生成するため、数分かかります）</p>
         </div>
         <div x-show="step === 3" class="text-center">
-          <h1 class="text-2xl font-medium text-gray-900 mb-6">STEP 3: タスク登録</h1>
+          <h1 class="text-2xl font-medium text-gray-900 mb-6">
+            STEP 3 <br class="block sm:hidden">
+            タスク登録
+          </h1>
           <img class="w-full sm:w-3/4 md:w-2/3 lg:w-1/2 xl:w-[95%] max-w-6xl block mx-auto mb-6 object-cover object-center rounded" 
           alt="step3_1" src="<%= asset_path('STEP3_1.png') %>">
-          <p class="text-base text-xl mb-12">タスク一覧からタスクを登録し、こなしていきましょう！</p>
+          <p class="text-base text-xl mb-12 block sm:hidden">
+            タスクを登録し、<br>
+            こなしていきましょう！
+          </p>
+          <p class="text-base text-xl mb-12 hidden sm:block">タスクを登録し、こなしていきましょう！</p>
           <img class="w-full sm:w-3/4 md:w-2/3 lg:w-1/2 xl:w-[95%] max-w-6xl block mx-auto mb-6 object-cover object-center rounded" 
           alt="step3_2" src="<%= asset_path('STEP3_2.png') %>">
-          <p class="text-base text-xl">登録、完了するたびに推しからのメッセージがもらえる！</p>
+          <p class="text-base text-xl block sm:hidden">
+            登録、完了するたびに<br>
+            推しからメッセージ<br>
+            をもらえる！
+          </p>
+          <p class="text-base text-xl hidden sm:block">登録、完了するたびに推しからメッセージをもらえる！</p>
         </div>
         <div x-show="step === 4" class="text-center">
-          <h1 class="text-2xl font-medium text-gray-900 mb-6">STEP 4: サブ（サード）タスク登録</h1>
+          <h1 class="text-2xl font-medium text-gray-900 mb-6">
+            STEP 4 <br class="block sm:hidden">
+            サブタスク登録
+          </h1>
           <img class="w-full sm:w-3/4 md:w-2/3 lg:w-1/2 xl:w-[95%] max-w-6xl block mx-auto mb-6 object-cover object-center rounded" 
           alt="step4" src="<%= asset_path('STEP4.png') %>">
-          <p class="text-base text-xl">タスクごとにサブタスクを登録可能！</p>
-          <p class="text-base text-xl">さらに、サブタスクごとにもサードタスクを登録可能！</p>
+          <p class="text-base text-xl block sm:hidden">
+            タスクごとにサブタスクを<br>
+            登録可能！
+          </p>
+          <p class="text-base text-xl block sm:hidden">
+            さらに、サブタスクごとに<br>
+            サードタスクを登録可能！
+          </p>
+          <p class="text-base text-xl hidden sm:block">タスクごとにサブタスクを登録可能！</p>
+          <p class="text-base text-xl hidden sm:block">さらに、サブタスクごとにもサードタスクを登録可能！</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
トップページ、ヘッダー、フッターのレスポンシブデザインの実装
・スマホでの見栄えよくするため、PC、スマホでの表示を分けた
・ヘッダーでの冗長な記述の削除
・スマホでのヘッダーのデザインの変更（マイページ等のリンクをドロップダウンで表示する）
・フッターのレイアウトを修正